### PR TITLE
Fixed: Input string was not in a correct format.

### DIFF
--- a/Oxide.Core/Logging/Logger.cs
+++ b/Oxide.Core/Logging/Logger.cs
@@ -45,7 +45,10 @@ namespace Oxide.Core.Logging
         /// <returns></returns>
         protected LogMessage CreateLogMessage(LogType type, string format, object[] args)
         {
-            return new LogMessage { Type = type, Message = string.Format(string.Format("{0} [{1}] {2}", DateTime.Now.ToShortTimeString(), type, format), args) };
+            LogMessage msg = new LogMessage { Type = type, Message = string.Format("{0} [{1}] {2}", DateTime.Now.ToShortTimeString(), type, format) };
+            if (args.Length != 0)
+                msg.Message = string.Format(msg.Message, args);
+            return msg;
         }
 
         /// <summary>


### PR DESCRIPTION
Was a format bug being reported on the forums for example here: http://forum.rustoxide.com/threads/death-messages.5831/page-8#post-59278

Changes: Only do the second string.Format() if there is actually args passed in.

Plugins can now use curly brackets in print()